### PR TITLE
feat: refresh token and logging

### DIFF
--- a/sample/sample.py
+++ b/sample/sample.py
@@ -1,6 +1,6 @@
 import asyncio
-import json
 import sys
+from datetime import datetime
 
 from aiokem.main import AioKem
 
@@ -12,18 +12,20 @@ async def main(username: str, password: str) -> None:
     kem = AioKem()
 
     # Call the login method
-    await kem.login(username, password)
+    await kem.authenticate(username, password)
 
     # Get the list of homes
     homes = await kem.get_homes()
-    print(json.dumps(homes, indent=4))
 
     # For each home, get the generator data
-    for home in homes:
-        data = await kem.get_generator_data(int(home["id"]))
-        print(json.dumps(data, indent=4))
-
-    await kem.close()
+    while True:
+        for home in homes:
+            data = await kem.get_generator_data(int(home["id"]))
+            print(
+                f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
+                f"Utility Voltage: {data['utilityVoltageV']}"
+            )
+        await asyncio.sleep(60)  # Sleep for 1 minute before fetching again
 
 
 if __name__ == "__main__":

--- a/sample/sample.py
+++ b/sample/sample.py
@@ -1,8 +1,16 @@
 import asyncio
+import logging
 import sys
-from datetime import datetime
 
 from aiokem.main import AioKem
+
+# Configure the logger
+_LOGGER = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 
 async def main(username: str, password: str) -> None:
@@ -21,10 +29,7 @@ async def main(username: str, password: str) -> None:
     while True:
         for home in homes:
             data = await kem.get_generator_data(int(home["id"]))
-            print(
-                f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
-                f"Utility Voltage: {data['utilityVoltageV']}"
-            )
+            _LOGGER.info("Utility Voltage: %s", data["utilityVoltageV"])
         await asyncio.sleep(60)  # Sleep for 1 minute before fetching again
 
 

--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -81,7 +81,6 @@ class AioKem:
             )
 
         except ClientConnectionError as e:
-            _LOGGER.exception("Connection error during authentication.")
             raise CommunicationError(f"Connection error: {e}") from e
 
     async def authenticate(self, username: str, password: str) -> None:

--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -1,5 +1,7 @@
 """AioKem class for interacting with Kohler Energy Management System (KEM) API."""
 
+import logging
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import Any
 
@@ -11,6 +13,14 @@ from .exceptions import (
     AuthenticationCredentialsError,
     AuthenticationError,
     CommunicationError,
+)
+
+# Configure the logger
+_LOGGER = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 AUTHENTICATION_URL = URL("https://kohler-homeenergy.okta.com/oauth2/default/v1/token")
@@ -36,33 +46,18 @@ class AioKem:
         self._session = (
             session if session else ClientSession(timeout=ClientTimeout(total=10))
         )
+        _LOGGER.info("AioKem instance initialized.")
 
-    async def login(self, username: str, password: str) -> None:
-        """Login to the server."""
-        headers = CIMultiDict(
-            {
-                "accept": "application/json",
-                "authorization": f"Basic {CLIENT_KEY}",
-                "content-type": "application/x-www-form-urlencoded",
-            }
-        )
-
-        data = CIMultiDict(
-            {
-                "grant_type": "password",
-                "username": username,
-                "password": password,
-                "scope": "openid profile offline_access email",
-            }
-        )
-
+    async def _authentication_helper(
+        self, headers: CIMultiDict, data: CIMultiDict
+    ) -> None:
         try:
+            _LOGGER.debug("Sending authentication request to %s", AUTHENTICATION_URL)
             response = await self._session.post(
                 AUTHENTICATION_URL, headers=headers, data=data
             )
             response_data = await response.json()
             if response.status != HTTPStatus.OK:
-                # Authentication returns 400 if the credentials are invalid
                 if response.status == HTTPStatus.BAD_REQUEST:
                     raise AuthenticationCredentialsError(
                         f"Invalid Credentials: "
@@ -83,13 +78,71 @@ class AioKem:
             if not self._refresh_token:
                 raise Exception("Login failed: No refresh token received")
 
+            self._token_expiration = response_data.get("expires_in")
+            self._token_expires_at = datetime.now() + timedelta(
+                seconds=self._token_expiration
+            )
+            _LOGGER.info(
+                "Authentication successful. Token expires at %s", self._token_expires_at
+            )
+
         except ClientConnectionError as e:
-            raise AuthenticationError(f"Connection error: {e}") from e
+            _LOGGER.exception("Connection error during authentication.")
+            raise CommunicationError(f"Connection error: {e}") from e
+
+    async def authenticate(self, username: str, password: str) -> None:
+        """Login to the server."""
+        _LOGGER.info("Authenticating user %s", username)
+        headers = CIMultiDict(
+            {
+                "accept": "application/json",
+                "authorization": f"Basic {CLIENT_KEY}",
+                "content-type": "application/x-www-form-urlencoded",
+            }
+        )
+
+        data = CIMultiDict(
+            {
+                "grant_type": "password",
+                "username": username,
+                "password": password,
+                "scope": "openid profile offline_access email",
+            }
+        )
+
+        await self._authentication_helper(headers, data)
+
+    async def refresh_token(self) -> None:
+        """Refresh the access token using the refresh token."""
+        _LOGGER.info("Refreshing access token.")
+        if not self._refresh_token:
+            raise AuthenticationError("No refresh token available")
+
+        headers = CIMultiDict(
+            {
+                "accept": "application/json",
+                "authorization": f"Basic {CLIENT_KEY}",
+                "content-type": "application/x-www-form-urlencoded",
+            }
+        )
+
+        data = CIMultiDict(
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+                "scope": "openid profile offline_access email",
+            }
+        )
+        await self._authentication_helper(headers, data)
 
     async def _get_helper(self, url: URL) -> dict[str, Any] | list[dict[str, Any]]:
         """Helper function to get data from the API."""
         if not self._token:
             raise AuthenticationError("Not authenticated")
+        if datetime.now() >= self._token_expires_at:
+            _LOGGER.info("Access token expired. Refreshing token.")
+            await self.refresh_token()
+
         headers = CIMultiDict(
             {
                 "apikey": API_KEY,
@@ -98,11 +151,12 @@ class AioKem:
         )
 
         try:
+            _LOGGER.debug("Sending GET request to %s", url)
             response = await self._session.get(url, headers=headers)
             response_data = await response.json()
             if response.status != 200:
                 if response.status == HTTPStatus.UNAUTHORIZED:
-                    raise AuthenticationError("Unauthorized: {response_data}")
+                    raise AuthenticationError(f"Unauthorized: {response_data}")
                 else:
                     raise CommunicationError(
                         f"Failed to fetch data: {response.status} {response_data}"
@@ -111,12 +165,12 @@ class AioKem:
         except ClientConnectionError as e:
             raise CommunicationError(f"Connection error: {e}") from e
 
-        if not response_data:
-            raise Exception("No data received")
+        _LOGGER.info("Data successfully fetched from %s", url)
         return response_data
 
     async def get_homes(self) -> list[dict[str, Any]]:
         """Get the list of homes."""
+        _LOGGER.info("Fetching list of homes.")
         response = await self._get_helper(HOMES_URL)
         if not isinstance(response, list):
             raise TypeError(
@@ -126,6 +180,7 @@ class AioKem:
 
     async def get_generator_data(self, generator_id: int) -> dict[str, Any]:
         """Get generator data for a specific generator."""
+        _LOGGER.info("Fetching generator data for generator ID %d", generator_id)
         url = URL(f"{API_BASE}/kem/api/v3/devices/{generator_id}")
         response = await self._get_helper(url)
         if not isinstance(response, dict):
@@ -137,4 +192,5 @@ class AioKem:
 
     async def close(self) -> None:
         """Close the session."""
+        _LOGGER.info("Closing the session.")
         await self._session.close()

--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -15,13 +15,7 @@ from .exceptions import (
     CommunicationError,
 )
 
-# Configure the logger
 _LOGGER = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 
 AUTHENTICATION_URL = URL("https://kohler-homeenergy.okta.com/oauth2/default/v1/token")
 CLIENT_KEY = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Fixtures for testing."""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+from aiokem.main import AioKem
+
+
+async def get_kem(mock_session: Mock) -> AioKem:
+    """Fixture to create a mock session and authenticate."""
+    mock_session.post = AsyncMock()
+    mock_session.get = AsyncMock()
+    kem = AioKem(session=mock_session)
+
+    # Mock the response for the login method
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "access_token": "mock_access_token",
+        "refresh_token": "mock_refresh_token",
+    }
+    mock_session.post.return_value = mock_response
+
+    await kem.authenticate("username", "password")
+    return kem
+
+
+def load_fixture_file(fixture_file: str) -> dict[str, Any]:
+    """Load fixtures from the JSON file."""
+    fixtures_path = Path(__file__).parent / "fixtures" / fixture_file
+    with fixtures_path.open() as f:
+        return json.load(f)


### PR DESCRIPTION
### Description of change

The authentication endpoint returns the token with an "expires_in" of 3600 seconds. Testing shows that after 75 minutes the bearer token will be rejected. Add support for automatically refreshing the token when it has expired.

Add info and debug logging

Refactor

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/kohlerlibs/aiokem/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
