### PR TITLE
Fix: Monotonic refresh

### DIFF
--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -124,7 +124,7 @@ class AioKem:
         if not self._token:
             raise AuthenticationError("Not authenticated")
         if time.monotonic() >= self._token_expires_at:
-            # Prevent entry and refreshing token multiple times
+            # Prevent reentry and refreshing token multiple times
             async with self._refresh_lock:
                 if time.monotonic() >= self._token_expires_at:
                     _LOGGER.debug("Access token expired. Refreshing token.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+import time
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 
@@ -231,7 +231,7 @@ async def test_auto_refresh_token():
     kem = await get_kem(mock_session)
     mock_session.post.reset_mock()
     # Set the token to expire in the past
-    token_expiration = kem._token_expires_at = datetime.now() + timedelta(seconds=-10)
+    token_expiration = kem._token_expires_at = time.monotonic() - 10000
 
     # Mock the response for the get_homes method
     mock_response = AsyncMock()


### PR DESCRIPTION
### Description of change

Fixes #12 

Use time.monotonic rather than now() to determine when bearer token expires and requires a refresh.

Add async lock around token refresh logic to prevent simultaneous refresh operations.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/kohlerlibs/aiokem/blob/main/CONTRIBUTING.md).
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
