### PR TITLE
fix: Require user to pass client session into init

### DIFF
--- a/sample/sample.py
+++ b/sample/sample.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import sys
 
+from aiohttp import ClientSession
+
 from aiokem.main import AioKem
 
 # Configure the logger
@@ -16,21 +18,27 @@ logging.basicConfig(
 async def main(username: str, password: str) -> None:
     """Main function to demonstrate the usage of AioKem."""
     # Create an instance of AioKem
-    # You can pass a custom session if needed, otherwise it will create a new one
-    kem = AioKem()
+    async with ClientSession() as session:
+        kem = AioKem(session=session)
 
-    # Call the login method
-    await kem.authenticate(username, password)
+        # Call the login method
+        await kem.authenticate(username, password)
 
-    # Get the list of homes
-    homes = await kem.get_homes()
+        # Get the list of homes
+        homes = await kem.get_homes()
 
-    # For each home, get the generator data
-    while True:
-        for home in homes:
-            data = await kem.get_generator_data(int(home["id"]))
-            _LOGGER.info("Utility Voltage: %s", data["utilityVoltageV"])
-        await asyncio.sleep(60)  # Sleep for 1 minute before fetching again
+        # For each home, get the generator data
+        try:
+            while True:
+                for home in homes:
+                    data = await kem.get_generator_data(int(home["id"]))
+                    _LOGGER.info("Utility Voltage: %s", data["utilityVoltageV"])
+                await asyncio.sleep(60)  # Sleep for 1 minute before fetching again
+        except KeyboardInterrupt:
+            _LOGGER.info("Exiting...")
+        except Exception as e:
+            _LOGGER.error("An error occurred: %s", e)
+        await kem.close()
 
 
 if __name__ == "__main__":

--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -49,11 +49,11 @@ CLIENT_TIMEOUT = ClientTimeout(total=10)
 class AioKem:
     """AioKem class for interacting with Kohler Energy Management System (KEM) API."""
 
-    def __init__(self, session: ClientSession = None) -> None:
+    def __init__(self, session: ClientSession) -> None:
         """Initialize the AioKem class."""
         self._token: str | None = None
         self._refresh_token: str | None = None
-        self._session = session or ClientSession(timeout=CLIENT_TIMEOUT)
+        self._session = session
         self._token_expires_at: float = 0
         self._token_expires_in: int = 0
         self._refresh_lock = asyncio.Lock()
@@ -207,5 +207,7 @@ class AioKem:
 
     async def close(self) -> None:
         """Close the session."""
-        _LOGGER.debug("Closing the session.")
-        await self._session.close()
+        _LOGGER.debug("Closing AioKem.")
+        self._session = None
+        self._token = None
+        self._refresh_token = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,9 +310,7 @@ async def test_close() -> None:
     mock_session = Mock()
     kem = await get_kem(mock_session)
     assert kem._session is not None
-    assert kem._token is not None
-    assert kem._refresh_token is not None
+
     await kem.close()
 
-    # Assert final state after close
     assert kem._session is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -302,3 +302,17 @@ async def test_auto_refresh_token() -> None:
         "refresh_token": kem._refresh_token,
         "scope": "openid profile offline_access email",
     }
+
+
+async def test_close() -> None:
+    """Tests the close method."""
+    # Create a mock session
+    mock_session = Mock()
+    kem = await get_kem(mock_session)
+    assert kem._session is not None
+    assert kem._token is not None
+    assert kem._refresh_token is not None
+    await kem.close()
+
+    # Assert final state after close
+    assert kem._session is None


### PR DESCRIPTION

### Description of change

Session was an optional parameter to the API initialization. Remove the optionality and require the caller to supply the session,

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/kohlerlibs/aiokem/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
