### PR TITLE
fix: retries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,9 @@ def load_fixture_file(fixture_file: str) -> dict[str, Any]:
 def generator_data() -> dict[str, Any]:
     """Fixture for generator data."""
     return load_fixture_file("generator_data.json")
+
+
+@pytest.fixture()
+def mock_session() -> Mock:
+    """Fixture for a mock session."""
+    return Mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from aiokem.main import AioKem
 
 
@@ -49,3 +51,9 @@ def load_fixture_file(fixture_file: str) -> dict[str, Any]:
     fixtures_path = Path(__file__).parent / "fixtures" / fixture_file
     with fixtures_path.open() as f:
         return json.load(f)
+
+
+@pytest.fixture()
+def generator_data() -> dict[str, Any]:
+    """Fixture for generator data."""
+    return load_fixture_file("generator_data.json")


### PR DESCRIPTION
### Description of change

When the application received a 504 error it was not retried. This is because the application was attempting to decode the JSON from the response which generated a ContentTypeError.

Rework the error handling to effectively handle this case and others; improve logging and add tests to improved coverage.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/kohlerlibs/aiokem/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
