### PR TITLE
fix: set client timeout

### DIFF
--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -148,6 +148,8 @@ class AioKem:
             response_data = await response.json()
         except ClientConnectionError as e:
             raise CommunicationError(f"Connection error: {e}") from e
+        except TimeoutError as e:
+            raise CommunicationError(f"Timeout error: {e}") from e
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             log_json_message(response_data)
@@ -249,6 +251,8 @@ class AioKem:
             )
         except ClientConnectionError as e:
             raise CommunicationError(f"Connection error: {e}") from e
+        except TimeoutError as e:
+            raise CommunicationError(f"Timeout error: {e}") from e
 
         if response.status == HTTPStatus.OK:
             try:

--- a/src/aiokem/main.py
+++ b/src/aiokem/main.py
@@ -306,7 +306,9 @@ class AioKem:
         _LOGGER.error(
             "Failed to get data after %s retries, error %s", attempt, last_error
         )
-        raise CommunicationError("Failed to get data after retries")
+        raise CommunicationError(
+            f"Failed to get data after {attempt} retries, error {last_error}"
+        ) from last_error
 
     async def get_homes(self) -> list[dict[str, Any]]:
         """Get the list of homes."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,13 @@ from aiokem.exceptions import (
     AuthenticationError,
     CommunicationError,
 )
-from aiokem.main import API_BASE, API_KEY, AUTHENTICATION_URL, HOMES_URL
+from aiokem.main import (
+    API_BASE,
+    API_KEY,
+    AUTHENTICATION_URL,
+    DEFAULT_CLIENT_TIMEOUT,
+    HOMES_URL,
+)
 from aiokem.message_logger import REDACTED
 from tests.conftest import MyAioKem, get_kem, load_fixture_file
 
@@ -54,6 +60,7 @@ async def test_authenticate(caplog: pytest.LogCaptureFixture) -> None:
         "password": "password",
         "scope": "openid profile offline_access email",
     }
+    assert mock_session.post.call_args.kwargs["timeout"] == DEFAULT_CLIENT_TIMEOUT
 
     assert '"access_token": "**redacted**"' in caplog.text
     assert '"refresh_token": "**redacted**"' in caplog.text
@@ -172,6 +179,7 @@ async def test_get_homes(
     # Create a mock session
     mock_session = Mock()
     kem = await get_kem(mock_session)
+    kem.set_timeout(5)
     # Mock the response for the get_homes method
     mock_response = AsyncMock()
     mock_response.status = 200
@@ -190,6 +198,7 @@ async def test_get_homes(
         mock_session.get.call_args[1]["headers"]["authorization"]
         == f"bearer {kem._token}"
     )
+    assert mock_session.get.call_args.kwargs["timeout"].total == 5
 
     assert "Generator 1" in caplog.text
     assert REDACTED in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,18 +297,18 @@ async def test_retries_1(mock_session: Mock) -> None:
     """Tests a single error with no retry policy."""
     kem = await get_kem(mock_session)
     kem.set_retry_policy(0, [0, 0, 0])
-    mock_session.get.side_effect = CommunicationError("Comms error")
+    mock_session.get.side_effect = ClientConnectionError("Comms error")
     with pytest.raises(CommunicationError) as excinfo:
         await kem.get_generator_data(12345)
     assert mock_session.get.call_count == 1
-    assert str(excinfo.value) == "Connection error: Comms error"
+    assert "Connection error: Comms error" in str(excinfo.value)
 
     mock_session.get.reset_mock()
     mock_session.get.side_effect = TimeoutError("Request timed out")
     with pytest.raises(CommunicationError) as excinfo:
         await kem.get_generator_data(12345)
     assert mock_session.get.call_count == 1
-    assert str(excinfo.value) == "Timeout error: Request timed out"
+    assert "Timeout error: Request timed out" in str(excinfo.value)
 
 
 async def test_retries_2(mock_session: Mock, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
### Description of change

The aiohttp client timeout was not being set and using the defaults. Now the client timeout is settable and is used by the get and post calls.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/kohlerlibs/aiokem/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
